### PR TITLE
[Bugfix] Ошибочное количество баллов за первое задание

### DIFF
--- a/asr_lab1.ipynb
+++ b/asr_lab1.ipynb
@@ -34,7 +34,7 @@
    "id": "e7765f57-93d1-4310-b2c6-b88189c16099",
    "metadata": {},
    "source": [
-    "# 1. Word Error Rate (7 баллов)"
+    "# 1. Word Error Rate (8 баллов)"
    ]
   },
   {


### PR DESCRIPTION
Ошибочное количество баллов за первое задание. Указано 7, а должно быть 8.